### PR TITLE
German locale grammar fix

### DIFF
--- a/src/chrome/locale/de-DE/policeman.properties
+++ b/src/chrome/locale/de-DE/policeman.properties
@@ -121,8 +121,8 @@ preferences_download_install_save = Installiere...
 preferences_download_install_failed = Installation fehlgeschlagen
 preferences_download_install_abort = Abbrechen
 
-preferences_enable = Aktiviere
-preferences_disable = Deaktiviere
+preferences_enable = Aktivieren
+preferences_disable = Deaktivieren
 preferences_installed_rulesets = Installierte Sätze
 preferences_enabled_rulesets = Aktive Sätze geordnet nach Priorität (Erster Treffer gewinnt)
 
@@ -138,7 +138,7 @@ decision = Entscheidung
 content_type = Inhalts-Typ
 origin_domain = Quell-Domain
 destination_domain = Ziel-Domain
-preferences_remove_rule = Entferne
+preferences_remove_rule = Entfernen
 preferences_promote_rule_to_rersistent = Dauerhaft machen
 preferences_custom_rule.allow = Erlaube
 preferences_custom_rule.reject = Blockiere


### PR DESCRIPTION
A single word was not in the correct case. Not too strange, but now it is right.

Update: Some strings that could potentially confuse users and were not 100% correct and have been changed. (0326826)

(The commit from 25th October, was to sync my fork with the source, after my translation got merged.)
