### PR TITLE
Update de-DE to include click options

### DIFF
--- a/src/chrome/locale/de-DE/policeman.properties
+++ b/src/chrome/locale/de-DE/policeman.properties
@@ -109,10 +109,10 @@ preferences_suspend_operation.tip = Keine der Regeln beachten
 preferences_reload_automaticaly_popup = Seite automatisch neu laden, wenn das Toolbar Popup versteckt ist
 preferences_reload_automaticaly_panelview = Seite automatisch neu laden, wenn das Menü versteckt ist
 
-preferences_toolbarbutton_events = Verhalten der Toolbarschaltfläche
+preferences_toolbarbutton_events = Verhalten der Toolbar Schaltfläche
 preferences_toolbarbutton_events.command = Beim Linksklick auf die Schaltfläche
 preferences_toolbarbutton_events.middleClick = Beim Mittelklick auf die Schaltfläche
-preferences_toolbarbutton_events.mouseover = Bei Mauszeigerberührung 
+preferences_toolbarbutton_events.mouseover = Bei Berührung mit dem Mauszeiger 
 preferences_toolbarbutton_actions.noop = Nichts tun
 preferences_toolbarbutton_actions.openWidget = Öffne Popup
 preferences_toolbarbutton_actions.openPreferences = Öffne Einstellungen


### PR DESCRIPTION
There is no easy translation for mouse over in German. I had one close to the source, but changed it to be easier understood. The German translation for "suspend" adds "(on/off)" to indicate that it is toggling suspension.
